### PR TITLE
chore(ci): add env variable to pass through the path prefix

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Install NPM Packages
         run: yarn install --immutable
       - name: Build Website
+        env:
+          PREFIX_PATHS: "true"
+          GOOGLE_VERIFICATION: "tE350sFqE19zPIz-admWd81Y-esA4VplEQYBOwS--L4"
+          GA_TRACKING_ID: "UA-172128342-1"
         run: yarn build:site
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"clean": "lerna exec -- rimraf build/ dist/",
 		"gen:tts": "lerna run gen:tts --stream",
 		"dev:site": "lerna run dev --stream --scope '@pomatez/website'",
-		"build:site": "cross-env PREFIX_PATHS=true lerna run build --stream --scope '@pomatez/website'",
+		"build:site": "lerna run build --stream --scope '@pomatez/website'",
 		"serve:site": "lerna run serve --stream --scope '@pomatez/website'",
 		"deploy:site": "lerna run deploy --stream --scope '@pomatez/website'",
 		"clean:site": "lerna run clean --scope '@pomatez/website'"


### PR DESCRIPTION
This should fix the website and allow it to be deployed. Checked on locally using http-serve in a pomatez/ folder and it works fine. Had originally tested it directly and forgot that github doesn't serve from the root folder and that it can be an issue.