### PR TITLE
378 Disable dragging for navigation links

### DIFF
--- a/app/renderer/src/components/Navigation.tsx
+++ b/app/renderer/src/components/Navigation.tsx
@@ -28,6 +28,7 @@ const Navigation: React.FC<Props> = ({ timerType }) => {
               exact={exact}
               to={path}
               type={timerType}
+              draggable="false"
               replace
             >
               <SVG name={icon} />


### PR DESCRIPTION
- Disabled dragging of navigation links.
- Tested on windows, installer & portable version.
- This pr fixes [378](https://github.com/zidoro/pomatez/issues/378)