### PR TITLE
fix: compact mode layout broke with 120 minutes max timer config

### DIFF
--- a/app/renderer/src/routes/Timer/Counter/CounterTimer.tsx
+++ b/app/renderer/src/routes/Timer/Counter/CounterTimer.tsx
@@ -28,7 +28,7 @@ const CounterTimer: React.FC<Props> = ({
     >
       {Number(hours) > 0 && (
         <>
-          <span>{hours}</span>
+          <span>{compact ? hours[hours.length - 1] : hours}</span>
           <span>:</span>
         </>
       )}

--- a/app/renderer/src/styles/routes/timer/control.ts
+++ b/app/renderer/src/styles/routes/timer/control.ts
@@ -156,6 +156,10 @@ export const StyledMainButton = styled.button`
 export const StyledCompactButton = styled.button<{ compact?: boolean }>`
   ${ControlButton}
   padding-right: ${(p) => (p.compact ? "1.6rem" : 0)};
+
+  & > svg {
+    width: ${(p) => (p.compact ? "1.6rem" : "inherit")};
+  }
 `;
 
 export const StyledSkipButton = styled.button`

--- a/app/renderer/src/styles/routes/timer/counter.ts
+++ b/app/renderer/src/styles/routes/timer/counter.ts
@@ -152,7 +152,7 @@ export const StyledCounterTimer = styled.h3<TimerProps>`
   }
 
   &.compact {
-    font-size: ${(p) => (p.fullscreen ? "4rem" : "2.5rem")};
+    font-size: ${(p) => (p.fullscreen ? "4rem" : "2.3rem")};
     width: unset;
     display: flex;
     gap: 0.25rem;


### PR DESCRIPTION
I have fixed broken layout bug which appeared after we added 120 minutes max config. I did minimum modifications to fix this. @roldanjr 

This PR fixes https://github.com/zidoro/pomatez/issues/389

_Tested on windows, installer and portable version._

Here are some comparisons, broken vs fixed screenshots.

![image](https://github.com/zidoro/pomatez/assets/45315917/bffd2d1f-0bb7-4736-8f37-20fc6d1e2028)
![image](https://github.com/zidoro/pomatez/assets/45315917/0d35f870-b89b-45b1-9938-a7fc38657e54)
