### PR TITLE
ci: Add snapcraft publish action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,6 +51,24 @@ jobs:
             **/*.exe
             **/*.snap
             **/*.blockmap
+  publish-to-snapcraft:
+    name: Publish to Snapcraft
+    needs:
+      - publish
+      - release-please
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: built-app-x64-linux
+      - name: Publish to Snapcraft
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
+        with:
+          snap: "*.snap"
+          release: stable
   publish-to-winget:
     name: Publish to WinGet
     needs:


### PR DESCRIPTION
For this action to work the secrets `SNAPCRAFT_STORE_LOGIN` must be available.

For the `snapcraft publish action` to work, the `SNAPCRAFT_STORE_LOGIN` secret must be available. It can be created as described in the documentation of the action (see [link](https://github.com/snapcore/action-publish/tree/v1/?tab=readme-ov-file#store-login)). It should be noted that the name of the secret is different from the one in the documentation to be more readable.

```bash
$ snapcraft export-login --snaps=PACKAGE_NAME \
      --acls package_access,package_push,package_update,package_release \
      exported.txt
```

refs https://github.com/zidoro/pomatez/pull/412, https://github.com/zidoro/pomatez/pull/418