### PR TITLE
Misc tauri fixes

### DIFF
--- a/app/tauri/src/commands.rs
+++ b/app/tauri/src/commands.rs
@@ -3,7 +3,7 @@
 
 use std::sync::Mutex;
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
-use tauri::{Builder, PhysicalSize, Runtime, Wry};
+use tauri::{Builder, LogicalSize, Runtime, Wry};
 
 #[non_exhaustive]
 struct WindowSize;
@@ -12,13 +12,18 @@ use crate::system_tray;
 use crate::updater;
 
 impl WindowSize {
-
     // Not sure why, if its due to UI scaling or what though these values seem to size smaller than the same values on electron
-    pub const MIN: PhysicalSize<u32> = PhysicalSize { width : 420, height: 602};
-    pub const COMPACT: PhysicalSize<u32> = PhysicalSize { width : 420, height: 80};
+    pub const MIN: LogicalSize<u32> = LogicalSize {
+        width: 420,
+        height: 602,
+    };
+    pub const COMPACT: LogicalSize<u32> = LogicalSize {
+        width: 420,
+        height: 80,
+    };
 }
 
-static ORIGINAL_SIZE: Mutex<PhysicalSize<u32>> = Mutex::new(WindowSize::MIN);
+static ORIGINAL_SIZE: Mutex<LogicalSize<u32>> = Mutex::new(WindowSize::MIN);
 
 static HAS_DECORATIONS: Mutex<bool> = Mutex::new(true);
 static IS_COMPACT: Mutex<bool> = Mutex::new(false);
@@ -55,8 +60,15 @@ fn set_always_on_top<R: Runtime>(always_on_top: bool, window: tauri::Window<R>) 
 }
 
 #[tauri::command]
-fn set_fullscreen_break<R: Runtime>(should_fullscreen: bool, always_on_top: bool, window: tauri::Window<R>) {
-    println!("set_fullscreen_break! {} {}", should_fullscreen, always_on_top);
+fn set_fullscreen_break<R: Runtime>(
+    should_fullscreen: bool,
+    always_on_top: bool,
+    window: tauri::Window<R>,
+) {
+    println!(
+        "set_fullscreen_break! {} {}",
+        should_fullscreen, always_on_top
+    );
     try_set_always_on_top(always_on_top, &window);
     if should_fullscreen {
         try_set_native_titlebar(true, &window);
@@ -84,14 +96,15 @@ fn try_set_always_on_top<R: Runtime>(always_on_top: bool, window: &tauri::Window
     }
 }
 
-fn try_set_min_size<R: Runtime>(size: Option<PhysicalSize<u32>>, window: &tauri::Window<R>) {
-    match window.set_min_size(size) {//Some(size)) {
+fn try_set_min_size<R: Runtime>(size: Option<LogicalSize<u32>>, window: &tauri::Window<R>) {
+    match window.set_min_size(size) {
+        //Some(size)) {
         Ok(_) => (),
         Err(e) => println!("There was a problem setting min size! {:?}", e),
     }
 }
 
-fn try_set_size<R: Runtime>(size: PhysicalSize<u32>, window: &tauri::Window<R>) {
+fn try_set_size<R: Runtime>(size: LogicalSize<u32>, window: &tauri::Window<R>) {
     match window.set_size(size) {
         Ok(_) => (),
         Err(e) => println!("There was a problem setting the window size! {:?}", e),
@@ -103,26 +116,32 @@ fn try_set_resizeable<R: Runtime>(resizeable: bool, window: &tauri::Window<R>) {
     println!("Window resizeable {:?}", resizeable);
     match window.set_resizable(resizeable) {
         Ok(_) => (),
-        Err(e) => println!("There was a problem making the window resizeable {:?}", e)
+        Err(e) => println!("There was a problem making the window resizeable {:?}", e),
     }
 }
 
 // Atm resizeable seems to cause a problem where the size cannot be set smaller than a certain amount
 // https://github.com/tauri-apps/tao/issues/561, just use resizeable until this is fixed.
-fn set_window_fixed_size<R: Runtime>(size: PhysicalSize<u32>, window: &tauri::Window<R>) {
+fn set_window_fixed_size<R: Runtime>(size: LogicalSize<u32>, window: &tauri::Window<R>) {
     let decorations = HAS_DECORATIONS.lock().unwrap();
     let new_height = size.height + (if *decorations { 0 } else { 34 });
-    let new_size = PhysicalSize { width : size.width, height: new_height};
+    let new_size = LogicalSize {
+        width: size.width,
+        height: new_height,
+    };
     try_set_size(new_size, window);
     try_set_resizeable(false, window);
 }
 
-fn set_window_resizeable<R: Runtime>(min_size: PhysicalSize<u32>, size: PhysicalSize<u32>, window: &tauri::Window<R>) {
+fn set_window_resizeable<R: Runtime>(
+    min_size: LogicalSize<u32>,
+    size: LogicalSize<u32>,
+    window: &tauri::Window<R>,
+) {
     try_set_resizeable(true, window);
     try_set_size(size, window);
     try_set_min_size(Some(min_size), window);
 }
-
 
 #[tauri::command]
 fn set_compact_mode<R: Runtime>(compact_mode: bool, window: tauri::Window<R>) {
@@ -134,11 +153,18 @@ fn set_compact_mode<R: Runtime>(compact_mode: bool, window: tauri::Window<R>) {
     if compact_mode {
         {
             let mut size = ORIGINAL_SIZE.lock().unwrap();
-            *size = window.outer_size().unwrap().clone();
+            *size = window
+                .outer_size()
+                .unwrap()
+                .to_logical(window.scale_factor().unwrap());
         }
         set_window_fixed_size(WindowSize::COMPACT, &window);
     } else {
-        set_window_resizeable(WindowSize::MIN, ORIGINAL_SIZE.lock().unwrap().clone(), &window);
+        set_window_resizeable(
+            WindowSize::MIN,
+            ORIGINAL_SIZE.lock().unwrap().clone(),
+            &window,
+        );
     }
 }
 
@@ -164,28 +190,38 @@ fn set_native_titlebar<R: Runtime>(use_native_titlebar: bool, window: tauri::Win
 fn try_set_native_titlebar<R: Runtime>(use_native_titlebar: bool, window: &tauri::Window<R>) {
     match window.set_decorations(use_native_titlebar) {
         Ok(_) => (),
-        Err(e) => println!("There was a problem setting the window decorations! {:?}", e),
+        Err(e) => println!(
+            "There was a problem setting the window decorations! {:?}",
+            e
+        ),
     }
     println!("set_native_titlebar! {}", use_native_titlebar);
 }
 
-
 /**
- * We could do this by passing the object into a custom function that adds the commands but I wanted
- * to practice more with rust. Plus it makes the setup cleaner.
+* We could do this by passing the object into a custom function that adds the commands but I wanted
+* to practice more with rust. Plus it makes the setup cleaner.
 
- * Switch to a function that takes and returns tauri::Builder<Wry> or uses a reference if we need to
- * switch it.
- */
+* Switch to a function that takes and returns tauri::Builder<Wry> or uses a reference if we need to
+* switch it.
+*/
 pub trait PomatezCommands {
     fn register_pomatez_commands(self) -> tauri::Builder<Wry>;
 }
 
 impl PomatezCommands for Builder<Wry> {
     fn register_pomatez_commands(self) -> tauri::Builder<Wry> {
-        self.invoke_handler(tauri::generate_handler![set_show, set_always_on_top,
-            set_fullscreen_break, set_compact_mode, set_ui_theme, set_native_titlebar,
-            system_tray::tray_icon_update, set_close, set_minimize, updater::check_for_updates,
+        self.invoke_handler(tauri::generate_handler![
+            set_show,
+            set_always_on_top,
+            set_fullscreen_break,
+            set_compact_mode,
+            set_ui_theme,
+            set_native_titlebar,
+            system_tray::tray_icon_update,
+            set_close,
+            set_minimize,
+            updater::check_for_updates,
             updater::install_update
         ])
     }

--- a/app/tauri/src/main_window.rs
+++ b/app/tauri/src/main_window.rs
@@ -1,0 +1,24 @@
+use tauri::{AppHandle, Manager, WindowBuilder};
+
+pub static MAIN_WINDOW_ID: &str = "main";
+
+pub fn create_main_window(handle: &AppHandle) {
+    if handle.get_window(MAIN_WINDOW_ID).is_some() {
+        return;
+    }
+    let window = WindowBuilder::new(handle, MAIN_WINDOW_ID, Default::default())
+        .inner_size(340f64, 502f64)
+        .resizable(true)
+        .title("pomatez")
+        .build()
+        .unwrap();
+
+    let window_clone = window.clone();
+    window.on_window_event(move |e| match e {
+        tauri::WindowEvent::CloseRequested { api, .. } => {
+            api.prevent_close();
+            window_clone.hide().unwrap();
+        }
+        _ => {}
+    })
+}

--- a/app/tauri/tauri.conf.json
+++ b/app/tauri/tauri.conf.json
@@ -36,18 +36,9 @@
         "signingIdentity": null
       },
       "publisher": "Roldan Montilla Jr",
-      "resources": [
-        "icons/icon.png"
-      ],
+      "resources": ["icons/icon.png"],
       "shortDescription": "",
-      "targets": [
-        "deb",
-        "appimage",
-        "msi",
-        "nsis",
-        "dmg",
-        "updater"
-      ],
+      "targets": ["deb", "appimage", "msi", "nsis", "dmg", "updater"],
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",
@@ -72,14 +63,9 @@
     "security": {
       "csp": null
     },
-    "windows": [
-      {
-        "fullscreen": false,
-        "height": 502,
-        "resizable": true,
-        "title": "pomatez",
-        "width": 340
-      }
-    ]
+    "windows": []
+  },
+  "plugins": {
+    "updater": {}
   }
 }


### PR DESCRIPTION
* Add empty updater config in development (refused to build otherwise)
* Switch to LogicalSize instead of PhysicalSize to support high-dpi screens like Macbooks
* Implement hiding to tray when exiting window

There's some rustfmt in there as well.

I can split these changes up into separate PRs as needed, and if you wish I could get rid of the rustfmt diffs. Let me know.