### PR TITLE
fix(tauri): check autostart status to prevent error with `@tauri-apps/plugin-autostart` on Windows

### DIFF
--- a/app/renderer/src/contexts/connectors/TauriConnector.tsx
+++ b/app/renderer/src/contexts/connectors/TauriConnector.tsx
@@ -18,7 +18,11 @@ import {
 } from "@pomatez/shareables";
 import { encodeSvg } from "../../utils";
 import { TraySVG } from "../../components";
-import { enable, disable } from "@tauri-apps/plugin-autostart";
+import {
+  enable,
+  disable,
+  isEnabled,
+} from "@tauri-apps/plugin-autostart";
 import { invoke } from "@tauri-apps/api/primitives";
 import { listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-shell";
@@ -92,7 +96,13 @@ export const TauriConnectorProvider: React.FC = ({ children }) => {
     if (settings.openAtLogin) {
       enable().catch((err) => console.error(err));
     } else {
-      disable().catch((err) => console.error(err));
+      // The autostart-plugin fails when trying to disble if it is already disabled
+      // https://github.com/tauri-apps/plugins-workspace/issues/24#issuecomment-1528958008
+      isEnabled()
+        .then((enabled) => {
+          if (enabled) disable().catch((err) => console.error(err));
+        })
+        .catch((err) => console.error(err));
     }
   }, [settings.openAtLogin]);
 


### PR DESCRIPTION
On Windows, Tauri throws an error when trying to enable the autostart feature when it is already on.

![image](https://github.com/zidoro/pomatez/assets/77246331/6846e1de-da81-4c9a-a244-0c17a9fcaf4c)

This PR checks that status to avoid the error

ref https://github.com/tauri-apps/plugins-workspace/issues/24#issuecomment-1528958008