### PR TITLE
feat: shortcuts for adding new cards with `Enter` & `Ctrl+Enter`

### DIFF
--- a/app/renderer/src/routes/Tasks/TaskFormButton.tsx
+++ b/app/renderer/src/routes/Tasks/TaskFormButton.tsx
@@ -25,7 +25,7 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
   const [isOpen, setOpen] = useTargetOutside({ ref: formRef });
 
   const doSubmit = useCallback(
-    (ref: HTMLInputElement | HTMLTextAreaElement) => {
+    (ref: HTMLInputElement | HTMLTextAreaElement, keepOpen = false) => {
       const { value } = ref;
       if (!value) return false;
 
@@ -37,7 +37,7 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
           formRef.current.reset();
         }
       }
-      setOpen(false);
+      if (!keepOpen) setOpen(false);
 
       return true;
     },
@@ -54,9 +54,9 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
           inputRef.current.focus();
 
           inputRef.current.onkeypress = (e: KeyboardEvent) => {
-            if (e.keyCode === 10 && inputRef.current) {
+            if (e.code === "Enter" && inputRef.current) {
               e.preventDefault();
-              doSubmit(inputRef.current);
+              doSubmit(inputRef.current, e.ctrlKey);
             }
           };
         }
@@ -66,10 +66,10 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
           autoSize(areaRef.current);
 
           areaRef.current.onkeypress = (e: KeyboardEvent) => {
-            if (e.keyCode === 10 && areaRef.current) {
+            if (e.code === "Enter" && areaRef.current) {
               e.preventDefault();
               if (
-                doSubmit(areaRef.current) &&
+                doSubmit(areaRef.current, e.ctrlKey) &&
                 areaRef?.current?.style?.height
               )
                 areaRef.current.style.height = "inherit";
@@ -85,7 +85,7 @@ const TaskFormButton: React.FC<Props> = ({ forList, onSubmit }) => {
       e.preventDefault();
 
       if (forList) {
-        inputRef.current && doSubmit(inputRef.current);
+        inputRef.current && doSubmit(inputRef.current, false);
       } else {
         if (areaRef.current && doSubmit(areaRef.current)) {
           areaRef.current.style.height = "inherit";

--- a/app/tauri/Cargo.lock
+++ b/app/tauri/Cargo.lock
@@ -2280,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.57"
+version = "0.10.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
 dependencies = [
  "bitflags 2.4.1",
  "cfg-if",
@@ -2312,9 +2312,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.93"
+version = "0.9.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
 dependencies = [
  "cc",
  "libc",

--- a/app/tauri/tauri.conf.json
+++ b/app/tauri/tauri.conf.json
@@ -36,18 +36,9 @@
         "signingIdentity": null
       },
       "publisher": "Roldan Montilla Jr",
-      "resources": [
-        "icons/icon.png"
-      ],
+      "resources": ["icons/icon.png"],
       "shortDescription": "",
-      "targets": [
-        "deb",
-        "appimage",
-        "msi",
-        "nsis",
-        "dmg",
-        "updater"
-      ],
+      "targets": ["deb", "appimage", "msi", "nsis", "dmg", "updater"],
       "windows": {
         "certificateThumbprint": null,
         "digestAlgorithm": "sha256",


### PR DESCRIPTION
Also fixed it for Tauri

Should fix or implement most of [#271](https://github.com/zidoro/pomatez/issues/271)

Before it worked on Electron though used old character codes rather than the .code value from the key event.