### PR TITLE
fix: electron and tauri signing (release 1.6.3 was skipped)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,6 +25,7 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.release_created
     uses: ./.github/workflows/build.yml
+    secrets: inherit
   build-tauri:
     name: "Build Tauri"
     needs: release-please

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,12 +11,12 @@ repos:
       - id: check-case-conflict
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.10
+    rev: v1.5.4
     hooks:
       - id: remove-crlf
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "" # Use the sha or tag you want to point at
+    rev: "v2.7.1" # Use the sha or tag you want to point at
     hooks:
       - id: prettier
         exclude: ^CHANGELOG\.md$

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "husky": "^4.3.8",
     "lerna": "^7.3.0",
     "lint-staged": "^10.5.4",
-    "prettier": "^2.8.8",
+    "prettier": "2.7.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.79.1",
     "rollup-plugin-typescript2": "^0.27.3",


### PR DESCRIPTION
The action itsself was fine though I forgot you need to add secrets: inherit for the secrets to run in underlying actions even on the same repo.

1.6.4 will be what 1.6.3 should have been.