### PR TITLE
refactor(renderer): extract common logic from Electron and Tauri connectors

### DIFF
--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect } from "react";
+import React, { Suspense } from "react";
 import { HashRouter as Router, Switch, Route } from "react-router-dom";
 import {
   ThemeProvider,
@@ -9,41 +9,14 @@ import { Layout, Preloader } from "components";
 import { compactRoutes, routes } from "config";
 import { useSelector } from "react-redux";
 import { AppStateTypes } from "store";
+import { useDisableNonNativeShortcuts } from "hooks/useDisableNonNativeShortcuts";
 
 export default function App() {
   const settings = useSelector(
     (state: AppStateTypes) => state.settings
   );
 
-  useEffect(() => {
-    const contextEvent = (event: MouseEvent) => {
-      if (event.target) {
-        let target = event.target as HTMLElement;
-        if (
-          target.tagName === "TEXTAREA" ||
-          (target.tagName === "INPUT" &&
-            (target as HTMLInputElement).type === "text")
-        ) {
-          return true;
-        }
-      }
-      event.preventDefault();
-      return false;
-    };
-    document.addEventListener("contextmenu", contextEvent);
-    return () =>
-      document.removeEventListener("contextmenu", contextEvent);
-  }, []);
-
-  useEffect(() => {
-    const middleMouseEvent = (event: MouseEvent) => {
-      if (event.button === 1) event.preventDefault();
-    };
-    window.addEventListener("auxclick", middleMouseEvent);
-
-    return () =>
-      window.removeEventListener("auxclick", middleMouseEvent);
-  }, []);
+  useDisableNonNativeShortcuts();
 
   return (
     <ThemeProvider>

--- a/app/renderer/src/components/Updater.tsx
+++ b/app/renderer/src/components/Updater.tsx
@@ -15,7 +15,7 @@ import {
   StyledDescriptionPreviewer,
   StyledTaskForm,
 } from "../styles";
-import { getInvokeConnector } from "../contexts";
+import { getInvokeConnector } from "contexts/InvokeConnectors";
 import { INSTALL_UPDATE } from "@pomatez/shareables";
 import { useNotification } from "../hooks";
 import notificationIcon from "../assets/logos/notification-dark.png";

--- a/app/renderer/src/contexts/ConnnectorContext.tsx
+++ b/app/renderer/src/contexts/ConnnectorContext.tsx
@@ -1,13 +1,11 @@
 import React from "react";
 import isElectron from "is-electron";
-import {
-  ElectronConnectorProvider,
-  ElectronInvokeConnector,
-} from "./connectors/ElectronConnector";
-import {
-  TauriConnectorProvider,
-  TauriInvokeConnector,
-} from "./connectors/TauriConnector";
+
+import { ElectronConnectorProvider } from "./connectors/ElectronConnector";
+import { TauriConnectorProvider } from "./connectors/TauriConnector";
+import { AgnosticConnector } from "./connectors/AgnosticConnector";
+
+import { getInvokeConnector } from "./InvokeConnectors";
 
 export type ConnectorProps = {
   onMinimizeCallback?: () => void;
@@ -19,15 +17,6 @@ export const ConnnectorContext = React.createContext<ConnectorProps>(
   {}
 );
 
-export function getInvokeConnector() {
-  if (isElectron()) {
-    return ElectronInvokeConnector;
-  } else if (window.__TAURI__) {
-    return TauriInvokeConnector;
-  }
-  return undefined;
-}
-
 export const ConnectorProvider: React.FC = ({ children }) => {
   let Connector: React.FC<ConnectorProps> = () => <>{children}</>;
   if (isElectron()) {
@@ -36,5 +25,9 @@ export const ConnectorProvider: React.FC = ({ children }) => {
     Connector = TauriConnectorProvider;
   }
 
-  return <Connector children={children} />;
+  return (
+    <AgnosticConnector invoker={getInvokeConnector()}>
+      <Connector children={children} />;
+    </AgnosticConnector>
+  );
 };

--- a/app/renderer/src/contexts/InvokeConnector.tsx
+++ b/app/renderer/src/contexts/InvokeConnector.tsx
@@ -1,6 +1,0 @@
-/**
- * Explicitly for calling invokes from the trigger rather than a setting change.
- */
-export type InvokeConnector = {
-  send: (event: string, ...payload: any) => void;
-};

--- a/app/renderer/src/contexts/InvokeConnectors.ts
+++ b/app/renderer/src/contexts/InvokeConnectors.ts
@@ -1,0 +1,53 @@
+import { invoke } from "@tauri-apps/api/primitives";
+import isElectron from "is-electron";
+
+/**
+ * An invoker is a module that can be used to trigger events in the main process.
+ *
+ * - On Electron, this is a function that sends an `IPC message`.
+ * - On Tauri, this is a function that invokes a `Tauri command`. **⚠️ A command is not the same as an event in Tauri.**
+ */
+export type InvokeConnector = {
+  send: (event: string, ...payload: any) => void;
+};
+
+export const ElectronInvoker: InvokeConnector = {
+  send: (event: string, ...payload: any) => {
+    const { electron } = window;
+
+    electron.send(event, ...payload);
+  },
+};
+
+export const TauriInvoker: InvokeConnector = {
+  /**
+   * Rust uses lowercase snake_case for function names, so we'll convert the event name to lower case for the calls.
+   * @param event
+   * @param payload
+   */
+  send: (event: string, ...payload: any) => {
+    invoke(event.toLowerCase(), ...payload).catch((err) =>
+      console.error(err)
+    );
+  },
+};
+
+/**
+ * This is a dummy invoker that does nothing.
+ */
+export const DefaultInvoker: InvokeConnector = {
+  send: () => {
+    console.log("This system does not support backend invokers.");
+  },
+};
+
+export function getInvokeConnector(): InvokeConnector {
+  if (isElectron()) {
+    return ElectronInvoker;
+  } else if (window.__TAURI__) {
+    return TauriInvoker;
+  }
+
+  // Default invoke connector (does nothing)
+  return DefaultInvoker;
+}

--- a/app/renderer/src/contexts/connectors/AgnosticConnector.tsx
+++ b/app/renderer/src/contexts/connectors/AgnosticConnector.tsx
@@ -1,0 +1,82 @@
+import React, { useContext, useEffect } from "react";
+import { useSelector } from "react-redux";
+import { AppStateTypes, SettingTypes } from "../../store";
+import { CounterContext } from "../CounterContext";
+import {
+  SET_ALWAYS_ON_TOP,
+  SET_COMPACT_MODE,
+  SET_FULLSCREEN_BREAK,
+  SET_NATIVE_TITLEBAR,
+  SHOW_WINDOW,
+  SET_UI_THEME,
+  TRAY_ICON_UPDATE,
+  SET_OPEN_AT_LOGIN,
+} from "@pomatez/shareables";
+import { useTrayIconUpdates } from "hooks/useTrayIconUpdates";
+import type { InvokeConnector } from "contexts/InvokeConnectors";
+
+type AgnosticConnectorProps = {
+  invoker: InvokeConnector;
+};
+
+export const AgnosticConnector: React.FC<AgnosticConnectorProps> = ({
+  children,
+  invoker,
+}) => {
+  const timer = useSelector((state: AppStateTypes) => state.timer);
+
+  const settings: SettingTypes = useSelector(
+    (state: AppStateTypes) => state.settings
+  );
+
+  const { shouldFullscreen } = useContext(CounterContext);
+
+  useEffect(() => {
+    if (!settings.enableFullscreenBreak) {
+      invoker.send(SHOW_WINDOW);
+    }
+  }, [invoker, timer.timerType, settings.enableFullscreenBreak]);
+
+  useEffect(() => {
+    invoker.send(SET_ALWAYS_ON_TOP, {
+      alwaysOnTop: settings.alwaysOnTop,
+    });
+  }, [invoker, settings.alwaysOnTop]);
+
+  useEffect(() => {
+    invoker.send(SET_FULLSCREEN_BREAK, {
+      shouldFullscreen,
+      alwaysOnTop: settings.alwaysOnTop,
+    });
+  }, [invoker, settings.alwaysOnTop, shouldFullscreen]);
+
+  useEffect(() => {
+    invoker.send(SET_COMPACT_MODE, {
+      compactMode: settings.compactMode,
+    });
+  }, [invoker, settings.compactMode]);
+
+  useEffect(() => {
+    invoker.send(SET_UI_THEME, {
+      isDarkMode: settings.enableDarkTheme,
+    });
+  }, [invoker, settings.enableDarkTheme]);
+
+  useEffect(() => {
+    invoker.send(SET_NATIVE_TITLEBAR, {
+      useNativeTitlebar: settings.useNativeTitlebar,
+    });
+  }, [invoker, settings.useNativeTitlebar]);
+
+  useEffect(() => {
+    invoker.send(SET_OPEN_AT_LOGIN, {
+      openAtLogin: settings.openAtLogin,
+    });
+  }, [invoker, settings.openAtLogin]);
+
+  useTrayIconUpdates((dataUrl) => {
+    invoker.send(TRAY_ICON_UPDATE, { dataUrl });
+  });
+
+  return <>{children}</>;
+};

--- a/app/renderer/src/contexts/connectors/ElectronConnector.tsx
+++ b/app/renderer/src/contexts/connectors/ElectronConnector.tsx
@@ -1,53 +1,28 @@
-import React, { useCallback, useContext, useEffect } from "react";
+import React, { useCallback } from "react";
 import { ConnnectorContext } from "../ConnnectorContext";
 import { useSelector } from "react-redux";
 import { AppStateTypes, SettingTypes } from "../../store";
-import { CounterContext } from "../CounterContext";
-import {
-  SET_ALWAYS_ON_TOP,
-  CLOSE_WINDOW,
-  SET_COMPACT_MODE,
-  SET_FULLSCREEN_BREAK,
-  MINIMIZE_WINDOW,
-  SET_NATIVE_TITLEBAR,
-  SHOW_WINDOW,
-  SET_UI_THEME,
-  TRAY_ICON_UPDATE,
-  SET_OPEN_AT_LOGIN,
-} from "@pomatez/shareables";
-import { InvokeConnector } from "../InvokeConnector";
-import { useTrayIconUpdates } from "hooks/useTrayIconUpdates";
-
-export const ElectronInvokeConnector: InvokeConnector = {
-  send: (event: string, ...payload: any) => {
-    const { electron } = window;
-
-    electron.send(event, ...payload);
-  },
-};
+import { CLOSE_WINDOW, MINIMIZE_WINDOW } from "@pomatez/shareables";
+import { ElectronInvoker } from "contexts/InvokeConnectors";
 
 export const ElectronConnectorProvider: React.FC = ({ children }) => {
   const { electron } = window;
-
-  const timer = useSelector((state: AppStateTypes) => state.timer);
 
   const settings: SettingTypes = useSelector(
     (state: AppStateTypes) => state.settings
   );
 
-  const { shouldFullscreen } = useContext(CounterContext);
-
   const onMinimizeCallback = useCallback(() => {
-    electron.send(MINIMIZE_WINDOW, {
+    ElectronInvoker.send(MINIMIZE_WINDOW, {
       minimizeToTray: settings.minimizeToTray,
     });
-  }, [electron, settings.minimizeToTray]);
+  }, [settings.minimizeToTray]);
 
   const onExitCallback = useCallback(() => {
-    electron.send(CLOSE_WINDOW, {
+    ElectronInvoker.send(CLOSE_WINDOW, {
       closeToTray: settings.closeToTray,
     });
-  }, [electron, settings.closeToTray]);
+  }, [settings.closeToTray]);
 
   const openExternalCallback = useCallback(() => {
     const links = document.querySelectorAll("a");
@@ -62,53 +37,6 @@ export const ElectronConnectorProvider: React.FC = ({ children }) => {
       }
     });
   }, [electron]);
-
-  useEffect(() => {
-    if (!settings.enableFullscreenBreak) {
-      electron.send(SHOW_WINDOW);
-    }
-  }, [electron, timer.timerType, settings.enableFullscreenBreak]);
-
-  useEffect(() => {
-    electron.send(SET_ALWAYS_ON_TOP, {
-      alwaysOnTop: settings.alwaysOnTop,
-    });
-  }, [electron, settings.alwaysOnTop]);
-
-  useEffect(() => {
-    electron.send(SET_FULLSCREEN_BREAK, {
-      shouldFullscreen,
-      alwaysOnTop: settings.alwaysOnTop,
-    });
-  }, [electron, settings.alwaysOnTop, shouldFullscreen]);
-
-  useEffect(() => {
-    electron.send(SET_COMPACT_MODE, {
-      compactMode: settings.compactMode,
-    });
-  }, [electron, settings.compactMode]);
-
-  useEffect(() => {
-    electron.send(SET_UI_THEME, {
-      isDarkMode: settings.enableDarkTheme,
-    });
-  }, [electron, settings.enableDarkTheme]);
-
-  useEffect(() => {
-    electron.send(SET_NATIVE_TITLEBAR, {
-      useNativeTitlebar: settings.useNativeTitlebar,
-    });
-  }, [electron, settings.useNativeTitlebar]);
-
-  useEffect(() => {
-    electron.send(SET_OPEN_AT_LOGIN, {
-      openAtLogin: settings.openAtLogin,
-    });
-  }, [electron, settings.openAtLogin]);
-
-  useTrayIconUpdates((dataUrl) => {
-    electron.send(TRAY_ICON_UPDATE, { dataUrl });
-  });
 
   return (
     <ConnnectorContext.Provider

--- a/app/renderer/src/hooks/useDisableNonNativeShortcuts.ts
+++ b/app/renderer/src/hooks/useDisableNonNativeShortcuts.ts
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+
+export const useDisableNonNativeShortcuts = () => {
+  // Disable context menu on all elements except textareas and inputs
+  useEffect(() => {
+    const contextEvent = (event: MouseEvent) => {
+      if (event.target) {
+        let target = event.target as HTMLElement;
+        if (
+          target.tagName === "TEXTAREA" ||
+          (target.tagName === "INPUT" &&
+            (target as HTMLInputElement).type === "text")
+        ) {
+          return true;
+        }
+      }
+      event.preventDefault();
+      return false;
+    };
+    document.addEventListener("contextmenu", contextEvent);
+    return () =>
+      document.removeEventListener("contextmenu", contextEvent);
+  }, []);
+
+  // Disable middle mouse button
+  useEffect(() => {
+    const middleMouseEvent = (event: MouseEvent) => {
+      if (event.button === 1) event.preventDefault();
+    };
+    window.addEventListener("auxclick", middleMouseEvent);
+
+    return () =>
+      window.removeEventListener("auxclick", middleMouseEvent);
+  }, []);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -14626,15 +14626,15 @@ prepend-http@^2.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==
 
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+
 prettier@^1.14.2:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-bytes@^5.3.0, pretty-bytes@^5.4.1:
   version "5.6.0"


### PR DESCRIPTION
This PR includes a refactor of the Tauri and Electron connectors.

I created an `AgnosticConnector` component to store the common code of both components.

The idea is to introduce in the AgnosticConnector the logic to manage global shortcuts (PR incoming)

