### PR TITLE
chore: error message thrown every second

### DIFF
--- a/app/renderer/src/contexts/connectors/ElectronConnector.tsx
+++ b/app/renderer/src/contexts/connectors/ElectronConnector.tsx
@@ -107,7 +107,7 @@ export const ElectronConnectorProvider: React.FC = ({ children }) => {
   }, [electron, settings.openAtLogin]);
 
   useTrayIconUpdates((dataUrl) => {
-    electron.send(TRAY_ICON_UPDATE, { dataUrl });
+    electron.send(TRAY_ICON_UPDATE, dataUrl);
   });
 
   return (


### PR DESCRIPTION
The incorrect object was being sent to the backend. This is an error only for the electron version.

I mark it as chore because the bug isn't yet in production

![image](https://github.com/zidoro/pomatez/assets/77246331/f2fc38b5-9cd6-4765-abb6-3054d31a8965)
