### PR TITLE
Fix analytics.ts link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Please consider starring this project to show your :blue_heart: and support. Tha
 
 ## :shield: Privacy
 
-This app has analytics that will track the number of users only and nothing more ([analytics.ts](https://github.com/zidoro/pomatez/blob/master/app/main/src/helpers/analytics.ts)).
+This app has analytics that will track the number of users only and nothing more ([analytics.ts](https://github.com/zidoro/pomatez/blob/master/app/electron/src/helpers/analytics.ts)).
 
 ## :newspaper: License
 


### PR DESCRIPTION
- The analytics.ts link is broken in README.md [shield-privacy](https://github.com/zidoro/pomatez#shield-privacy)

<img width="1229" alt="image" src="https://github.com/zidoro/pomatez/assets/43899/b1c0eb88-a128-473c-bb94-0aaa91998dd9">
