### PR TITLE
fix: react warning that was blocking the previous release

### DIFF
--- a/app/renderer/src/contexts/CounterContext.tsx
+++ b/app/renderer/src/contexts/CounterContext.tsx
@@ -406,7 +406,7 @@ const CounterProvider: React.FC = ({ children }) => {
     settings.notificationType,
     settings.autoStartWorkTime,
     settings.enableVoiceAssistance,
-    hasNotified60Seconds,
+    hasNotified30Seconds,
     hasNotified60Seconds,
     hasNotifiedBreak,
     setHasNotified30Seconds,


### PR DESCRIPTION
I had forgotten to check that the master was building without the warnings as it was building fine locally. These warnings are really irritating that they fully block a release.