### PR TITLE
chore: update winget release action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: windows-latest
     continue-on-error: true
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - uses: vedantmgoyal2009/winget-releaser@main
         with:
           identifier: Zidoro.Pomatez
           installers-regex: 'setup\.exe$'


### PR DESCRIPTION
the maintainer has moved this to require @main to work. This is a bad idea but seems the only way for this to run for now.