### PR TITLE
fix(shortcuts): block Esc via webContents instead of globalShortcut

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,57 @@
+---
+name: Sync Upstream Release
+
+on:
+  schedule:
+    - cron: "0 9 1 * *" # 1st of every month at 09:00 UTC
+  workflow_dispatch: # manual trigger any time
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout fork
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check upstream for new release
+        id: check
+        run: |
+          UPSTREAM=$(curl -s https://api.github.com/repos/zidoro/pomatez/releases/latest \
+            | jq -r '.tag_name')
+          CURRENT=$(git tag --list 'v*' --sort=-version:refname | head -1 | sed 's/-esc-fix//')
+          echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+          if [ "$UPSTREAM" = "$CURRENT" ]; then
+            echo "new=false" >> $GITHUB_OUTPUT
+            echo "No new upstream release ($UPSTREAM). Nothing to do."
+          else
+            echo "new=true" >> $GITHUB_OUTPUT
+            echo "New upstream release: $UPSTREAM (we have $CURRENT)"
+          fi
+
+      - name: Rebase patch onto new upstream tag
+        if: steps.check.outputs.new == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/zidoro/pomatez.git
+          git fetch upstream
+          TAG=${{ steps.check.outputs.upstream }}
+          git checkout -b fix/esc-key-global-shortcut-leak-$TAG upstream/$TAG
+          git cherry-pick origin/fix/esc-key-global-shortcut-leak..HEAD || true
+          git push origin fix/esc-key-global-shortcut-leak-$TAG
+
+      - name: Open PR if rebase succeeded
+        if: steps.check.outputs.new == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=${{ steps.check.outputs.upstream }}
+          gh pr create \
+            --title "chore: rebase ESC fix onto upstream $TAG" \
+            --body "Upstream released $TAG. Rebased fix/esc-key-global-shortcut-leak onto the new tag. Review, merge, then build and update the homebrew cask per PATCH.md Option B." \
+            --base master \
+            --head fix/esc-key-global-shortcut-leak-$TAG || echo "PR already exists"

--- a/PATCH.md
+++ b/PATCH.md
@@ -1,0 +1,161 @@
+# Pomatez — Patch Notes
+
+## Active Patch: fix/esc-key-global-shortcut-leak
+
+**Upstream PR**: https://github.com/zidoro/pomatez/pull/752  
+**Status**: Open — pending upstream merge  
+**Branch**: `fix/esc-key-global-shortcut-leak`
+
+### Problem
+
+`activateFullScreenShortcuts` registers `Esc` as a `globalShortcut` with a no-op
+callback during mandatory breaks. This intercepts Esc **system-wide**, starving
+every other application (terminals, editors, browsers) of the key while a break
+is active. Same root cause as upstream issue #49 (Ctrl-R blocked, now closed).
+
+### Fix
+
+Replaced `globalShortcut` for Esc with `webContents.on('before-input-event')` on
+the break window. Fires only when Pomatez has focus — which is always true during a
+mandatory fullscreen break (`alwaysOnTop + fullScreen`). `CommandOrControl+W` retains
+a `globalShortcut` because it is an OS-level close binding on macOS that bypasses
+webContents input.
+
+**Files changed:**
+- `app/electron/src/helpers/globalShortcuts.ts`
+- `app/electron/src/lifecycleEventHandlers/fullScreenBreak.ts`
+- `app/electron/src/lifecycleEventHandlers/__tests__/fullScreenBreak.test.ts`
+
+---
+
+## How to Vend This Patch Locally
+
+### Option A — asar hot-patch (instant, fragile)
+
+Patches the installed app in-place. **Breaks on `brew upgrade pomatez`** — re-run after
+every upgrade until upstream merges.
+
+```bash
+# 1. Extract the installed asar
+cd /tmp
+npx asar extract /Applications/Pomatez.app/Contents/Resources/app.asar pomatez-patched
+
+# 2. Apply the fix to globalShortcuts.js
+cat > pomatez-patched/build/helpers/globalShortcuts.js << 'EOF'
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.deactivateFullScreenShortcuts = exports.activateFullScreenShortcuts = exports.activateGlobalShortcuts = void 0;
+var electron_1 = require("electron");
+var EXIT_SHORTCUTS = { QUIT: "CommandOrControl+W" };
+function activateGlobalShortcuts(shortcuts) {
+    shortcuts.map(function (_a) {
+        var key = _a.key, callback = _a.callback;
+        electron_1.globalShortcut.register(key, callback);
+    });
+}
+exports.activateGlobalShortcuts = activateGlobalShortcuts;
+function activateFullScreenShortcuts(win, exitFullScreenCallback) {
+    win.webContents.on("before-input-event", handleBreakInput);
+    electron_1.globalShortcut.register(EXIT_SHORTCUTS.QUIT, exitFullScreenCallback);
+}
+exports.activateFullScreenShortcuts = activateFullScreenShortcuts;
+function deactivateFullScreenShortcuts(win) {
+    win.webContents.removeListener("before-input-event", handleBreakInput);
+    electron_1.globalShortcut.unregister(EXIT_SHORTCUTS.QUIT);
+}
+exports.deactivateFullScreenShortcuts = deactivateFullScreenShortcuts;
+function handleBreakInput(event, input) {
+    if (input.type === "keyDown" && input.key === "Escape") {
+        event.preventDefault();
+    }
+}
+EOF
+
+# 3. Repack and replace
+npx asar pack pomatez-patched /tmp/app-patched.asar
+sudo cp /Applications/Pomatez.app/Contents/Resources/app.asar \
+        /Applications/Pomatez.app/Contents/Resources/app.asar.bak
+sudo cp /tmp/app-patched.asar /Applications/Pomatez.app/Contents/Resources/app.asar
+
+# 4. Restart Pomatez
+pkill -x Pomatez || true
+open /Applications/Pomatez.app
+```
+
+### Option B — Homebrew tap (durable, recommended)
+
+Builds from this fork and installs via a custom cask. Survives system restarts.
+Pin until upstream PR #752 merges, then revert to the official cask.
+
+```bash
+# 1. Build deps (requires node + yarn)
+cd "${WS_DIR:-$HOME/ws}/git/src/extern/pomatez"
+yarn install
+
+# 2. Build macOS DMG
+yarn build:mwl
+# DMG produced at: app/electron/dist/Pomatez-*.dmg
+
+# 3. Create GitHub release on fork
+DMG=$(ls app/electron/dist/Pomatez-*-mac-arm64.dmg 2>/dev/null || \
+      ls app/electron/dist/Pomatez-*.dmg | head -1)
+SHA=$(shasum -a 256 "$DMG" | awk '{print $1}')
+gh release create v1.11.0-esc-fix \
+  --repo richtong/pomatez \
+  --title "v1.11.0-esc-fix: block Esc via webContents" \
+  --notes "Patch for upstream PR #752 — Esc no longer intercepted system-wide during breaks." \
+  "$DMG"
+RELEASE_URL=$(gh release view v1.11.0-esc-fix --repo richtong/pomatez --json assets \
+  --jq '.assets[0].browserDownloadUrl')
+
+# 4. Create/update homebrew tap
+# Assumes richtong/homebrew-tap exists; create with:
+#   gh repo create richtong/homebrew-tap --public
+BREW_TAP_DIR="${WS_DIR:-$HOME/ws}/git/src/extern/homebrew-tap"
+mkdir -p "$BREW_TAP_DIR/Casks"
+cat > "$BREW_TAP_DIR/Casks/pomatez.rb" << CASK
+cask "pomatez" do
+  version "1.11.0-esc-fix"
+  # Update sha256 after building:
+  sha256 "${SHA}"
+  url "${RELEASE_URL}"
+  name "Pomatez"
+  desc "Pomodoro timer (patched: ESC key fix — upstream PR #752)"
+  homepage "https://zidoro.github.io/pomatez"
+  app "Pomatez.app"
+  zap trash: [
+    "~/Library/Application Support/pomatez",
+    "~/Library/Preferences/com.roldanjr.pomatez.plist",
+  ]
+end
+CASK
+
+# 5. Install from tap
+brew tap richtong/tap "$BREW_TAP_DIR"
+brew install --cask richtong/tap/pomatez
+```
+
+### Reverting to upstream (after PR #752 merges)
+
+```bash
+brew uninstall --cask richtong/tap/pomatez
+brew untap richtong/tap
+brew install --cask pomatez
+# Then remove this submodule:
+#   git submodule deinit extern/pomatez
+#   git rm extern/pomatez
+```
+
+---
+
+## Tracking
+
+| Field | Value |
+|---|---|
+| Upstream repo | https://github.com/zidoro/pomatez |
+| Our fork | https://github.com/richtong/pomatez |
+| Upstream PR | https://github.com/zidoro/pomatez/pull/752 |
+| Patch status | `pr_open` |
+| Pinned version | `1.11.0-esc-fix` |
+| Viability TTL | 90 days — re-evaluate if upstream PR stalls |
+| Related issue | upstream #49 (same root, closed, Linux) |

--- a/PATCH.md
+++ b/PATCH.md
@@ -22,6 +22,7 @@ a `globalShortcut` because it is an OS-level close binding on macOS that bypasse
 webContents input.
 
 **Files changed:**
+
 - `app/electron/src/helpers/globalShortcuts.ts`
 - `app/electron/src/lifecycleEventHandlers/fullScreenBreak.ts`
 - `app/electron/src/lifecycleEventHandlers/__tests__/fullScreenBreak.test.ts`
@@ -71,11 +72,11 @@ function handleBreakInput(event, input) {
 }
 EOF
 
-# 3. Repack and replace
+# 3. Repack and replace (scriptable — no drag-and-drop required, per r-cto-dev125)
 npx asar pack pomatez-patched /tmp/app-patched.asar
-sudo cp /Applications/Pomatez.app/Contents/Resources/app.asar \
-        /Applications/Pomatez.app/Contents/Resources/app.asar.bak
-sudo cp /tmp/app-patched.asar /Applications/Pomatez.app/Contents/Resources/app.asar
+cp /Applications/Pomatez.app/Contents/Resources/app.asar \
+   /Applications/Pomatez.app/Contents/Resources/app.asar.bak
+cp /tmp/app-patched.asar /Applications/Pomatez.app/Contents/Resources/app.asar
 
 # 4. Restart Pomatez
 pkill -x Pomatez || true
@@ -150,12 +151,12 @@ brew install --cask pomatez
 
 ## Tracking
 
-| Field | Value |
-|---|---|
-| Upstream repo | https://github.com/zidoro/pomatez |
-| Our fork | https://github.com/richtong/pomatez |
-| Upstream PR | https://github.com/zidoro/pomatez/pull/752 |
-| Patch status | `pr_open` |
-| Pinned version | `1.11.0-esc-fix` |
-| Viability TTL | 90 days — re-evaluate if upstream PR stalls |
-| Related issue | upstream #49 (same root, closed, Linux) |
+| Field          | Value                                       |
+| -------------- | ------------------------------------------- |
+| Upstream repo  | https://github.com/zidoro/pomatez           |
+| Our fork       | https://github.com/richtong/pomatez         |
+| Upstream PR    | https://github.com/zidoro/pomatez/pull/752  |
+| Patch status   | `pr_open`                                   |
+| Pinned version | `1.11.0-esc-fix`                            |
+| Viability TTL  | 90 days — re-evaluate if upstream PR stalls |
+| Related issue  | upstream #49 (same root, closed, Linux)     |

--- a/app/electron/src/helpers/globalShortcuts.ts
+++ b/app/electron/src/helpers/globalShortcuts.ts
@@ -1,6 +1,6 @@
-import { globalShortcut } from "electron";
+import { globalShortcut, BrowserWindow } from "electron";
 
-const EXIT_SHORTCUTS = { ESCAPE: "Esc", QUIT: "CommandOrControl+W" };
+const EXIT_SHORTCUTS = { QUIT: "CommandOrControl+W" };
 
 type ShortCut = {
   key: string;
@@ -13,16 +13,39 @@ export function activateGlobalShortcuts(shortcuts: ShortCut[]) {
   });
 }
 
+/**
+ * Block Esc and Cmd+W within the break fullscreen window using
+ * webContents.before-input-event instead of globalShortcut.
+ *
+ * globalShortcut.registerAll(['Esc', ...]) intercepts Esc system-wide,
+ * starving every other application of the key while a break is active.
+ * before-input-event fires only when the Pomatez window has focus,
+ * which is sufficient: the window is fullscreen + alwaysOnTop during
+ * breaks so it will always be focused when the user presses Esc.
+ */
 export function activateFullScreenShortcuts(
+  win: BrowserWindow,
   exitFullScreenCallback: () => void
 ) {
-  globalShortcut.registerAll(
-    [EXIT_SHORTCUTS.ESCAPE, EXIT_SHORTCUTS.QUIT],
-    exitFullScreenCallback
-  );
+  // Block Esc at the window level — does not leak to other apps.
+  win.webContents.on("before-input-event", handleBreakInput);
+
+  // CommandOrControl+W still needs a global shortcut because it is a
+  // OS-level window-close binding that bypasses webContents input on macOS.
+  globalShortcut.register(EXIT_SHORTCUTS.QUIT, exitFullScreenCallback);
 }
 
-export function deactivateFullScreenShortcuts() {
-  globalShortcut.unregister(EXIT_SHORTCUTS.ESCAPE);
+export function deactivateFullScreenShortcuts(win: BrowserWindow) {
+  win.webContents.removeListener("before-input-event", handleBreakInput);
   globalShortcut.unregister(EXIT_SHORTCUTS.QUIT);
+}
+
+/** Swallows Escape key events — prevents users skipping a mandatory break. */
+function handleBreakInput(
+  event: { preventDefault(): void },
+  input: { type: string; key: string }
+): void {
+  if (input.type === "keyDown" && input.key === "Escape") {
+    event.preventDefault();
+  }
 }

--- a/app/electron/src/lifecycleEventHandlers/__tests__/fullScreenBreak.test.ts
+++ b/app/electron/src/lifecycleEventHandlers/__tests__/fullScreenBreak.test.ts
@@ -38,10 +38,13 @@ describe("Fullscreen break", () => {
       setToolTip: jest.spyOn(tray, "setToolTip"),
       setContextMenu: jest.spyOn(tray, "setContextMenu"),
     };
+    // Esc is no longer a globalShortcut — it is handled via webContents
     expect(globalShortcut.isRegistered("Esc")).toBe(false);
     expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(
       false
     );
+
+    const webContentsOnSpy = jest.spyOn(window.webContents, "on");
 
     setFullscreenBreakHandler(
       { shouldFullscreen: true, alwaysOnTop: true },
@@ -69,8 +72,13 @@ describe("Fullscreen break", () => {
     );
     expect(fullscreenState.isFullscreen).toEqual(true);
 
-    // Verify that shortcuts have been set
-    expect(globalShortcut.isRegistered("Esc")).toBe(true);
+    // Esc is blocked via webContents.before-input-event (window-local, not global)
+    expect(webContentsOnSpy).toHaveBeenCalledWith(
+      "before-input-event",
+      expect.any(Function)
+    );
+    expect(globalShortcut.isRegistered("Esc")).toBe(false);
+    // Cmd+W still uses globalShortcut (OS-level close binding on macOS)
     expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(
       true
     );
@@ -94,11 +102,11 @@ describe("Fullscreen break", () => {
       setToolTip: jest.spyOn(tray, "setToolTip"),
       setContextMenu: jest.spyOn(tray, "setContextMenu"),
     };
-    globalShortcut.registerAll(["Esc", "CommandOrControl+W"], () => {});
-    expect(globalShortcut.isRegistered("Esc")).toBe(true);
-    expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(
-      true
-    );
+    // Simulate state from a prior enter-fullscreen: Cmd+W registered, webContents listener active
+    globalShortcut.register("CommandOrControl+W", () => {});
+    const removeListenerSpy = jest.spyOn(window.webContents, "removeListener");
+    expect(globalShortcut.isRegistered("Esc")).toBe(false);
+    expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(true);
 
     setFullscreenBreakHandler(
       { shouldFullscreen: false, alwaysOnTop: true },
@@ -126,11 +134,13 @@ describe("Fullscreen break", () => {
     );
     expect(fullscreenState.isFullscreen).toEqual(false);
 
-    // Verify that shortcuts have been set
-    expect(globalShortcut.isRegistered("Esc")).toBe(false);
-    expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(
-      false
+    // Verify before-input-event listener removed and Cmd+W unregistered
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      "before-input-event",
+      expect.any(Function)
     );
+    expect(globalShortcut.isRegistered("Esc")).toBe(false);
+    expect(globalShortcut.isRegistered("CommandOrControl+W")).toBe(false);
 
     // Verify that tray has been updated
     expect(traySpies.setToolTip).toHaveBeenCalledTimes(1);

--- a/app/electron/src/lifecycleEventHandlers/fullScreenBreak.ts
+++ b/app/electron/src/lifecycleEventHandlers/fullScreenBreak.ts
@@ -56,7 +56,9 @@ export const setFullscreenBreakHandler = (
   if (shouldFullscreen) {
     setFullScreen(true, alwaysOnTop, win, isFullscreen);
 
-    activateFullScreenShortcuts(() => {});
+    if (win) {
+      activateFullScreenShortcuts(win, () => {});
+    }
 
     tray?.setToolTip("");
     tray?.setContextMenu(
@@ -69,7 +71,9 @@ export const setFullscreenBreakHandler = (
   } else {
     setFullScreen(false, alwaysOnTop, win, isFullscreen);
 
-    deactivateFullScreenShortcuts();
+    if (win) {
+      deactivateFullScreenShortcuts(win);
+    }
     tray?.setToolTip(trayTooltip);
     tray?.setContextMenu(contextMenu);
   }


### PR DESCRIPTION
## Problem

`activateFullScreenShortcuts` calls `globalShortcut.registerAll(['Esc', 'CommandOrControl+W'], () => {})` to prevent users from escaping a mandatory break. This registers Esc as a **system-wide global shortcut** with a no-op callback, which intercepts every Esc key press on the machine while the break is active — including in terminals, editors, browsers, and any other application.

This is the same root cause as #49 (Ctrl-R blocked system-wide, now closed) — both stem from `blockShortcutKeys` / `activateFullScreenShortcuts` using `globalShortcut` for keys that should only be blocked within the Pomatez window.

## Fix

Replace `globalShortcut` for Esc with `webContents.on('before-input-event')` on the break window:

```ts
win.webContents.on('before-input-event', (event, input) => {
  if (input.type === 'keyDown' && input.key === 'Escape') {
    event.preventDefault();
  }
});
```

This fires only when the Pomatez window has focus. During a mandatory break the window is `fullScreen + alwaysOnTop`, so it will always be focused when the user presses Esc — the break-prevention behaviour is fully preserved.

`CommandOrControl+W` is kept as a `globalShortcut` because it is an OS-level window-close binding on macOS that bypasses `webContents` input events.

## Impact
- ✅ Esc is no longer captured system-wide during breaks
- ✅ Break enforcement is unchanged — Esc still does nothing inside the break window
- ✅ Tests updated to assert `webContents.on('before-input-event')` is called and `globalShortcut.isRegistered('Esc')` is `false`

## Related
- Closes (same root cause) #49 — "The app blocks Ctrl-R hotkey"