### PR TITLE
Security: Prototype pollution / arbitrary localStorage key injection via unsanitized string interpolation

### DIFF
--- a/app/electron/src/helpers/getFromStorage.ts
+++ b/app/electron/src/helpers/getFromStorage.ts
@@ -6,7 +6,7 @@ const getFromStorage = async (
 ): Promise<any> => {
   try {
     const data = await win.webContents.executeJavaScript(
-      `localStorage.getItem("${key}")`
+      `localStorage.getItem(${JSON.stringify(key)})`
     );
     if (data === null) {
       return undefined;


### PR DESCRIPTION
## Summary

Security: Prototype pollution / arbitrary localStorage key injection via unsanitized string interpolation

## Problem

**Severity**: `Critical` | **File**: `app/electron/src/helpers/getFromStorage.ts:L6`

The Electron helper reads from localStorage by executing JavaScript built from an unescaped `key` string: ``localStorage.getItem("${key}")``. If an attacker can influence the key, they can break out of the string literal and execute arbitrary code in the page context. This is a code injection sink in a privileged desktop renderer.

## Solution

Never construct JavaScript source with string concatenation. Pass the key as an argument to the page context, or better, avoid `executeJavaScript` entirely and use a safe IPC bridge or preload-exposed API with strict key validation.

## Changes

- `app/electron/src/helpers/getFromStorage.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced